### PR TITLE
Removal of "List of 2013 Events" title

### DIFF
--- a/docs/events/external.md
+++ b/docs/events/external.md
@@ -21,7 +21,6 @@ Visit [@OpenResearchCal](https://twitter.com/OpenResearchCal) on twitter to find
 
 
 <div class="span3">
-	<h3>List of 2013 Events</h3>
 <div id="upcoming"></div><!--/span-->
 </div>
 <div class="span9">


### PR DESCRIPTION
It appeared to just be some extra text rather than an artefact of the calendar iframe embed. 